### PR TITLE
Keep compatible with debian 3.15-2build1

### DIFF
--- a/gpspy3/gps.py
+++ b/gpspy3/gps.py
@@ -363,6 +363,12 @@ class GPS(GPSCommon, GPSData, GPSJson):
             else:
                 GPSJson.stream(self, flags, devpath)
 
+#Compatibility with older version:
+gps = GPS
+gpsfix = GPSFix
+gpsdata = GPSData
+gps.next = GPS.__next__
+
 if __name__ == '__main__':
     import getopt
     import sys


### PR DESCRIPTION
Hi. I am porting some tools I have to python3. I noticed that the interface changed in this port and it doesn't match exactly with the version delivered by Ubuntu/Debian.
I just created some aliases, so that client applications don't need to be changed.
